### PR TITLE
Use the function 'org-link-types' if available

### DIFF
--- a/org-linkany.el
+++ b/org-linkany.el
@@ -584,7 +584,9 @@ This function is called when you do persistent-action that is bound to C-z."
                           (yaxception:get-stack-trace-string e)))))
 
 (defadvice org-insert-link (around org-linkany/add-head activate)
-  (let ((org-link-types org-link-types))
+  (let ((org-link-types (if (fboundp 'org-link-types)
+                            (org-link-types)
+                          org-link-types)))
     (pushnew "head" org-link-types :test 'equal)
     ad-do-it))
 


### PR DESCRIPTION
Newer version of org-mode have converted the variable `org-link-types` to function, causing `org-linkany` to fail on such versions.